### PR TITLE
[iioadaptor] Implement IIO proximityadaptor. Fixes MER#2062

### DIFF
--- a/adaptors/iioadaptor/iioadaptor.h
+++ b/adaptors/iioadaptor/iioadaptor.h
@@ -55,7 +55,8 @@ class IioAdaptor : public SysfsAdaptor
         IIO_MAGNETOMETER, // magn_3d
         IIO_ROTATION, // dev_rotation, quaternion
         IIO_ALS, // als
-        IIO_TILT // incli_3d
+        IIO_TILT, // incli_3d
+        IIO_PROXIMITY // proximity als
     };
 
     struct iio_device {
@@ -130,9 +131,12 @@ private:
     // Device number for the sensor (-1 if not found)
     int devNodeNumber;
 
+    int proximityThreshold;
+
     DeviceAdaptorRingBuffer<TimedXyzData>* iioXyzBuffer_;
     DeviceAdaptorRingBuffer<TimedUnsigned>* alsBuffer_;
     DeviceAdaptorRingBuffer<CalibratedMagneticFieldData>* magnetometerBuffer_;
+    DeviceAdaptorRingBuffer<ProximityData>* proximityBuffer_;
 
     iio_device iioDevice;
 
@@ -141,6 +145,7 @@ private:
     TimedXyzData* timedData;
     CalibratedMagneticFieldData *calData;
     TimedUnsigned *uData;
+    ProximityData *proximityData;
 
 private slots:
     void setup();

--- a/adaptors/iioadaptor/iioadaptorplugin.cpp
+++ b/adaptors/iioadaptor/iioadaptorplugin.cpp
@@ -36,6 +36,7 @@ void IioAdaptorPlugin::Register(class Loader&)
     sm.registerDeviceAdaptor<IioAdaptor>("gyroscopeadaptor");
     sm.registerDeviceAdaptor<IioAdaptor>("magnetometeradaptor");
     sm.registerDeviceAdaptor<IioAdaptor>("alsadaptor");
+    sm.registerDeviceAdaptor<IioAdaptor>("proximityadaptor");
 }
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)

--- a/core/hybrisadaptor.cpp
+++ b/core/hybrisadaptor.cpp
@@ -354,8 +354,6 @@ void HybrisManager::initManager()
                 m_sensorState[i].m_maxDelay = maxDelay;
 
                 setDelay(m_sensorArray[i].handle, delay, true);
-                setActive(m_sensorArray[i].handle, true);
-                setDelay(m_sensorArray[i].handle, delay, false);
 
                 sensordLogD("delay = %d [%d, %d]",
                             m_sensorState[i].m_delay,

--- a/rpm/sensorfw-qt5-binder.spec
+++ b/rpm/sensorfw-qt5-binder.spec
@@ -1,5 +1,5 @@
 Name: hybris-libsensorfw-qt5-binder
-Version:    0.11.1
+Version:    0.11.3
 Release:    0
 Provides: hybris-libsensorfw-qt5 = %{version}-%{release}
 Conflicts: hybris-libsensorfw-qt5 <= 0.10.9

--- a/rpm/sensorfw-qt5-hybris.spec
+++ b/rpm/sensorfw-qt5-hybris.spec
@@ -1,5 +1,5 @@
 Name: hybris-libsensorfw-qt5-hal
-Version:    0.11.1
+Version:    0.11.3
 Release:    0
 Provides: hybris-libsensorfw-qt5 = %{version}-%{release}
 Conflicts: hybris-libsensorfw-qt5 <= 0.10.9

--- a/rpm/sensorfw-qt5.spec
+++ b/rpm/sensorfw-qt5.spec
@@ -1,6 +1,6 @@
 Name:       sensorfw-qt5
 Summary:    Sensor Framework Qt5
-Version:    0.11.1
+Version:    0.11.3
 Release:    0
 Group:      System/Sensor Framework
 License:    LGPLv2+

--- a/sensord-qt5.pc
+++ b/sensord-qt5.pc
@@ -4,7 +4,7 @@ libdir=${prefix}/lib/
 
 Name: Sensorfw-qt5
 Description: Sensord for Qt 5
-Version: 0.11.1
+Version: 0.11.3
 Requires:
 Libs: -L${libdir} -lsensorclient-qt5 -lsensordatatypes-qt5
 Cflags: -I${includedir} -I${includedir}/datatypes -I${includedir}/filters

--- a/sensord.pc
+++ b/sensord.pc
@@ -4,7 +4,7 @@ libdir=${prefix}/lib/
 
 Name: Sensorfw
 Description: Sensorfw
-Version: 0.11.1
+Version: 0.11.3
 Requires:
 Libs: -L${libdir} -lsensorclient -lsensordatatypes
 Cflags: -I${includedir} -I${includedir}/datatypes -I${includedir}/filters


### PR DESCRIPTION
Implements IIO sensor support for proximity sensors.
Requires a `threshold` value in the configuration file of the `sensors.d.conf` directory.
If the `threshold` is not defined, a default value will be used.